### PR TITLE
Fallback case in case Key K is none in env.py

### DIFF
--- a/clients/python/percolate/percolate/utils/env.py
+++ b/clients/python/percolate/percolate/utils/env.py
@@ -51,7 +51,10 @@ def sync_model_keys(connection_string:str=None) -> dict:
     
     d = {}
     for row in rows:
+        
         k = row['token_env_key'] 
+        if k is None:
+            continue
         if token:= os.environ.get(k):
             d[k] = True
             pg.execute(f"""update p8."LanguageModelApi" set token=%s where token_env_key = %s""", data=(token,k))


### PR DESCRIPTION
# Overview

env.py throws an error in case it encounters a key who's value is `None`. This PR is to add a conditional case to ascertain that the loop continues and skips keys with non-existent `None` values. 